### PR TITLE
Raise FileNotFoundError when face annotations missing

### DIFF
--- a/rtdetr_pytorch/setup_face_detection_complete.sh
+++ b/rtdetr_pytorch/setup_face_detection_complete.sh
@@ -196,15 +196,15 @@ class FaceLandmarkDataset(torch.utils.data.Dataset):
         self.num_landmarks = num_landmarks
         self.return_visibility = return_visibility
         
-        # For now, create dummy data if annotation file doesn't exist
-        if os.path.exists(ann_file):
-            with open(ann_file, 'r') as f:
-                self.annotations = json.load(f)
-            self.image_ids = list(self.annotations.keys())
-        else:
-            print(f"Warning: Annotation file {ann_file} not found. Using dummy data.")
-            self.annotations = {}
-            self.image_ids = []
+        # Load annotations
+        if not os.path.exists(ann_file):
+            raise FileNotFoundError(
+                f"Annotation file '{ann_file}' not found. "
+                "Please check the dataset path.")
+
+        with open(ann_file, 'r') as f:
+            self.annotations = json.load(f)
+        self.image_ids = list(self.annotations.keys())
         
         # If no annotations, create dummy data
         if len(self.image_ids) == 0:

--- a/rtdetr_pytorch/src/data/face_landmark_dataset.py
+++ b/rtdetr_pytorch/src/data/face_landmark_dataset.py
@@ -20,14 +20,14 @@ class FaceLandmarkDataset(torch.utils.data.Dataset):
         self.return_visibility = return_visibility
         
         # Load annotations
-        if os.path.exists(ann_file):
-            with open(ann_file, 'r') as f:
-                self.annotations = json.load(f)
-            self.image_ids = list(self.annotations.keys())
-        else:
-            print(f"Warning: Annotation file {ann_file} not found. Using dummy data.")
-            self.annotations = {}
-            self.image_ids = []
+        if not os.path.exists(ann_file):
+            raise FileNotFoundError(
+                f"Annotation file '{ann_file}' not found. "
+                "Please check the dataset path.")
+
+        with open(ann_file, 'r') as f:
+            self.annotations = json.load(f)
+        self.image_ids = list(self.annotations.keys())
             
         # Create dummy data if needed
         if len(self.image_ids) == 0:


### PR DESCRIPTION
## Summary
- stop silently creating dummy annotations in `FaceLandmarkDataset`
- do the same for the example dataset class in `setup_face_detection_complete.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683fefa5f538832ba64bcbacc740d0e8